### PR TITLE
3 loosen controls for emote resizing

### DIFF
--- a/BillTube2.js
+++ b/BillTube2.js
@@ -292,7 +292,7 @@ console.log("Loading Mobile Theme");
 console.log("Loading Desktop Theme");
 //Load some dependencies for the base theme
 $('head').append("<link rel='stylesheet' href='//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css' />");
-$('head').append("<link rel='stylesheet' href='https://cdn.jsdelivr.net/gh/intentionallyIncomplete/BadMovieCytube@dd24eb1dc231728be8ccc806db1a6c29e17e8f19/base.css' />");
+$('head').append("<link rel='stylesheet' href='https://cdn.jsdelivr.net/gh/intentionallyIncomplete/BadMovieCytube@ec9533c9422a2b7bc8c9e8ca0d787b1ec1e296cf/base.css' />");
 $('head').append("<link rel='stylesheet' href='https://unpkg.com/@videojs/themes@1/dist/city/index.css' />");
 $.getScript("//dl.dropbox.com/s/m5kd8r2slhnfu1c/notifications.js");
 $.getScript("https://cdn.jsdelivr.net/gh/BillTube/BillTube2/avatars.js");

--- a/BillTube2.js
+++ b/BillTube2.js
@@ -292,7 +292,7 @@ console.log("Loading Mobile Theme");
 console.log("Loading Desktop Theme");
 //Load some dependencies for the base theme
 $('head').append("<link rel='stylesheet' href='//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css' />");
-$('head').append("<link rel='stylesheet' href='https://cdn.jsdelivr.net/gh/intentionallyIncomplete/BadMovieCytube@ec9533c9422a2b7bc8c9e8ca0d787b1ec1e296cf/base.css' />");
+$('head').append("<link rel='stylesheet' href='https://cdn.jsdelivr.net/gh/intentionallyIncomplete/BadMovieCytube@2219c2f33d5a9189632e4b3ae3d47a1f3a23cb1b/base.css' />");
 $('head').append("<link rel='stylesheet' href='https://unpkg.com/@videojs/themes@1/dist/city/index.css' />");
 $.getScript("//dl.dropbox.com/s/m5kd8r2slhnfu1c/notifications.js");
 $.getScript("https://cdn.jsdelivr.net/gh/BillTube/BillTube2/avatars.js");

--- a/BillTube2.js
+++ b/BillTube2.js
@@ -292,7 +292,7 @@ console.log("Loading Mobile Theme");
 console.log("Loading Desktop Theme");
 //Load some dependencies for the base theme
 $('head').append("<link rel='stylesheet' href='//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css' />");
-$('head').append("<link rel='stylesheet' href='https://cdn.jsdelivr.net/gh/BillTube/BillTube2@latest/base.css' />");
+$('head').append("<link rel='stylesheet' href='https://cdn.jsdelivr.net/gh/intentionallyIncomplete/BadMovieCytube@dd24eb1dc231728be8ccc806db1a6c29e17e8f19/base.css' />");
 $('head').append("<link rel='stylesheet' href='https://unpkg.com/@videojs/themes@1/dist/city/index.css' />");
 $.getScript("//dl.dropbox.com/s/m5kd8r2slhnfu1c/notifications.js");
 $.getScript("https://cdn.jsdelivr.net/gh/BillTube/BillTube2/avatars.js");

--- a/base.css
+++ b/base.css
@@ -2243,8 +2243,7 @@ code {
     }
 }
 img.chat-picture {
-    max-height: 150px;
-    max-width: 240px;
+    max-width: 200px;
     border-radius: 3px;
     transition: .8s ease;
     vertical-align: baseline;

--- a/base.css
+++ b/base.css
@@ -2243,8 +2243,8 @@ code {
     }
 }
 img.chat-picture {
-    max-height: 110px;
-    max-width: 150px;
+    max-height: 200px;
+    max-width: 320px;
     border-radius: 3px;
     transition: .8s ease;
     vertical-align: baseline;

--- a/base.css
+++ b/base.css
@@ -2243,8 +2243,8 @@ code {
     }
 }
 img.chat-picture {
-    max-height: 200px;
-    max-width: 320px;
+    max-height: 150px;
+    max-width: 240px;
     border-radius: 3px;
     transition: .8s ease;
     vertical-align: baseline;


### PR DESCRIPTION
Giphy embeds set to max-width 200px for now. can change later, but the functionality is there, and should roughly correspond to the max size of emotes in the channel